### PR TITLE
Update opts.rs

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -30,7 +30,7 @@ impl Options {
             .optflag("V", "version", "Show this program's version")
             .optflag("f", "foreground", "Run in foreground")
             .optflag("d", "debug", "Run in foreground and show debug info")
-            .optmulti("o", "o", "Provide a FUSE option", "OPTION");
+            .optmulti("o", "", "Provide a FUSE option", "OPTION");
         let mut args: Vec<String> = env::args().collect();
 
         // Try to get the program name from the command-line. Otherwise, just use the cargo


### PR DESCRIPTION
Fix the following panic:

```
$ RUST_BACKTRACE=1 $HOME/.cargo/bin/qcow2-fuse -h
thread 'main' panicked at 'the long_name (second argument) should be longer than a single character, or an empty string for none', /Users/ybart/.cargo/registry/src/github.com-1ecc6299db9ec823/getopts-0.2.18/src/lib.rs:551:5
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic
   6: getopts::Options::optmulti
   7: qcow2_fuse::opts::Options::new
   8: qcow2_fuse::main
   9: std::rt::lang_start::{{closure}}
  10: std::panicking::try::do_call
  11: __rust_maybe_catch_panic
  12: std::rt::lang_start_internal
  13: main
```

